### PR TITLE
Switch to local .binaryTarget() paths to avoid downloads and improve package efficiency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,18 +2,6 @@
 
 import PackageDescription
 
-let version = "main"
-
-let UnbluCoreSDK_CHECKSUM = "c31bc61e4f18ce11c8c1c1600a0622dacf3b3dc442e261a54b89e39fdb92d991"
-let UnbluFirebaseNotificationModule_CHECKSUM = "76f451ec56b8c6bc0e5eda04301e12ae907943b412e5c50503ef83422bce2ad4"
-let UnbluOpenTokCallModule_CHECKSUM = "211a1e14e127a2eb09d1bda05b646082c616430d1b785883f5824dbb0d71f51f"
-let UnbluLiveKitCallModule_CHECKSUM = "b37d2d8a884b6a2965c8a2ffd00c5ed8480b58952e8a4a2bb3a996328386d823"
-let UnbluMobileCoBrowsing_CHECKSUM = "5ca663bff70f3bb5e7604567f450ba025fefca3fa0b9cfb250712a8cbd60f9d5"
-let UnbluCallKitModule_CHECKSUM = "d42df4d8004f0ffac5ad90a73b34aa16364ab329f766888f248ffcc06b46f3e4"
-
-
-
-
 let package = Package(
     name: "UnbluMobileSDK",
     platforms: [
@@ -25,47 +13,41 @@ let package = Package(
             targets: ["UnbluCoreSDK","UnbluMobileCoBrowsingModule"]),
         .library(
             name: "UnbluFirebaseNotificationModule",
-            targets: ["UnbluFirebaseNotificationModule"]),        
+            targets: ["UnbluFirebaseNotificationModule"]),
         .library(
             name: "UnbluLiveKitWebRtcProvider",
             targets: ["UnbluLiveKitCallModule"]),
         .library(
             name: "UnbluVonageWebRtcProvider",
             targets: ["UnbluOpenTokCallModule"]),
-         .library(
+        .library(
             name: "UnbluCallKitModule",
             targets: ["UnbluCallKitModule"])
     ],
     targets: [
-            .binaryTarget(
-                name: "UnbluCoreSDK",
-                url: "https://github.com/unblu/ios-sdk-xcframeworks/blob/\(version)/UnbluCoreSDK.xcframework.zip?raw=true",
-                checksum: UnbluCoreSDK_CHECKSUM
-                ),
-            .binaryTarget(
-                name: "UnbluFirebaseNotificationModule",
-                url: "https://github.com/unblu/ios-sdk-xcframeworks/blob/\(version)/UnbluFirebaseNotificationModule.xcframework.zip?raw=true",
-                checksum: UnbluFirebaseNotificationModule_CHECKSUM
-                ),
-            .binaryTarget(
-                name: "UnbluOpenTokCallModule",
-                url: "https://github.com/unblu/ios-sdk-xcframeworks/blob/\(version)/UnbluOpenTokCallModule.xcframework.zip?raw=true",
-                checksum: UnbluOpenTokCallModule_CHECKSUM
-                ),
-            .binaryTarget(
-                name: "UnbluLiveKitCallModule",
-                url: "https://github.com/unblu/ios-sdk-xcframeworks/blob/\(version)/UnbluLiveKitCallModule.xcframework.zip?raw=true",
-                checksum: UnbluLiveKitCallModule_CHECKSUM
-                ),
-            .binaryTarget(
-                name: "UnbluMobileCoBrowsingModule",
-                url: "https://github.com/unblu/ios-sdk-xcframeworks/blob/\(version)/UnbluMobileCoBrowsingModule.xcframework.zip?raw=true",
-                checksum: UnbluMobileCoBrowsing_CHECKSUM
-                ),
-             .binaryTarget(
-                name: "UnbluCallKitModule",
-                url: "https://github.com/unblu/ios-sdk-xcframeworks/blob/\(version)/UnbluCallKitModule.xcframework.zip?raw=true",
-                checksum: UnbluCallKitModule_CHECKSUM
-                )
+        .binaryTarget(
+            name: "UnbluCoreSDK",
+            path: "UnbluCoreSDK.xcframework.zip"
+        ),
+        .binaryTarget(
+            name: "UnbluFirebaseNotificationModule",
+            path: "UnbluFirebaseNotificationModule.xcframework.zip"
+        ),
+        .binaryTarget(
+            name: "UnbluOpenTokCallModule",
+            path: "UnbluOpenTokCallModule.xcframework.zip"
+        ),
+        .binaryTarget(
+            name: "UnbluLiveKitCallModule",
+            path: "UnbluLiveKitCallModule.xcframework.zip"
+        ),
+        .binaryTarget(
+            name: "UnbluMobileCoBrowsingModule",
+            path: "UnbluMobileCoBrowsingModule.xcframework.zip"
+        ),
+        .binaryTarget(
+            name: "UnbluCallKitModule",
+            path: "UnbluCallKitModule.xcframework.zip"
+        )
     ]
 )


### PR DESCRIPTION
✨ Description

This PR updates the Package.swift to define .binaryTarget() entries using relative local paths instead of remote URLs.

---

💥 Problem

Previously, the package declared binary targets with URLs like:
https://github.com/unblu/ios-sdk-xcframeworks/blob/4.9.12/UnbluCoreSDK.xcframework.zip?raw=true

This caused:
- Extra network downloads during package resolution.
- Rate limiting issues (HTTP 429) when builds ran frequently in CI/CD.
- Unnecessary duplication, since the .xcframeworks were already included in the repository.

---

✅ Solution

- Use .binaryTarget(name: path:) with relative local paths pointing to the included .xcframeworks.

---

🚀 Benefits

- More efficient builds, since frameworks are only fetched once.
- No rate-limiting issues, leading to faster and more reliable builds (especially in CI/CD).
- Simpler maintenance — no need to manage binary URLs or checksums.